### PR TITLE
Changes radio buttons to stars

### DIFF
--- a/app/star-rating.jsx
+++ b/app/star-rating.jsx
@@ -31,7 +31,6 @@ class Star extends React.Component {
   onChange(e) {
      const rating = parseInt(e.target.value);
      this.props.onChange(rating);
-     console.log('shows checked is true on click', this);
   }
 
   render() {

--- a/app/star-rating.jsx
+++ b/app/star-rating.jsx
@@ -31,6 +31,7 @@ class Star extends React.Component {
   onChange(e) {
      const rating = parseInt(e.target.value);
      this.props.onChange(rating);
+     console.log('shows checked is true on click', this);
   }
 
   render() {

--- a/app/star-rating.jsx
+++ b/app/star-rating.jsx
@@ -43,7 +43,7 @@ class Star extends React.Component {
 
      return [
         (<input key={id + "__input"} className="star-rating__input" type="radio" id={id} name={name} value={value} checked={checked} onChange={e => this.onChange(e)}></input>),
-        (<label key={id + "__label"} className="star-rating__label" htmlFor={id}></label>),
+        (<label key={id + "__label"} className={this.props.checked ? "star-rating__clicked" : "star-rating__label"} htmlFor={id}></label>),
      ];
   }
 }

--- a/app/star-rating.jsx
+++ b/app/star-rating.jsx
@@ -43,7 +43,7 @@ class Star extends React.Component {
 
      return [
         (<input key={id + "__input"} className="star-rating__input" type="radio" id={id} name={name} value={value} checked={checked} onChange={e => this.onChange(e)}></input>),
-        (<label key={id + "__label"} className={this.props.checked ? "star-rating__clicked" : "star-rating__label"} htmlFor={id}></label>),
+        (<label key={id + "__label"} className={this.props.checked ? "star-rating__label--checked" : "star-rating__label"} htmlFor={id}></label>),
      ];
   }
 }

--- a/app/star-rating.sass
+++ b/app/star-rating.sass
@@ -17,8 +17,8 @@ h1
     direction: rtl
     border: none
 
-    .star-rating__clicked::before,
-    .star-rating__clicked ~ .star-rating__label:before
+    .star-rating__label--checked::before,
+    .star-rating__label--checked ~ .star-rating__label:before
         font-family: "Font Awesome 5 Free"
         font-weight: 900
         content: "\f005"

--- a/app/star-rating.sass
+++ b/app/star-rating.sass
@@ -15,7 +15,7 @@ h1
     display: inline-block
     unicode-bidi: bidi-override
     direction: rtl
-    border-width: 0px
+    border: none
 
     .star-rating__clicked::before,
     .star-rating__clicked ~ .star-rating__label:before

--- a/app/star-rating.sass
+++ b/app/star-rating.sass
@@ -10,7 +10,7 @@ h1
 
 #app
    font-size: 3em
-   
+
 .star-rating
     display: inline-block
     unicode-bidi: bidi-override
@@ -21,3 +21,10 @@ h1
         font-family: "Font Awesome 5 Free"
         font-weight: 400
         content: "\f005"
+
+    .star-rating__label:hover::before,
+    .star-rating__label:hover ~ .star-rating__label:before
+        font-family: "Font Awesome 5 Free"
+        font-weight: 900
+        content: "\f005"
+        color: rgba(255, 255, 150, 100)

--- a/app/star-rating.sass
+++ b/app/star-rating.sass
@@ -37,4 +37,4 @@ h1
         color: rgba(255, 255, 150, 100)
 
     .star-rating__input
-        opacity: 0
+        display: none

--- a/app/star-rating.sass
+++ b/app/star-rating.sass
@@ -28,3 +28,6 @@ h1
         font-weight: 900
         content: "\f005"
         color: rgba(255, 255, 150, 100)
+
+    .star-rating__input
+        opacity: 0

--- a/app/star-rating.sass
+++ b/app/star-rating.sass
@@ -10,3 +10,14 @@ h1
 
 #app
    font-size: 3em
+   
+.star-rating
+    display: inline-block
+    unicode-bidi: bidi-override
+    direction: rtl
+    border-width: 0px
+
+    .star-rating__label::before
+        font-family: "Font Awesome 5 Free"
+        font-weight: 400
+        content: "\f005"

--- a/app/star-rating.sass
+++ b/app/star-rating.sass
@@ -17,13 +17,6 @@ h1
     direction: rtl
     border: none
 
-    .star-rating__label--checked::before,
-    .star-rating__label--checked ~ .star-rating__label:before
-        font-family: "Font Awesome 5 Free"
-        font-weight: 900
-        content: "\f005"
-        color: rgba(255, 255, 0, 100)
-
     .star-rating__label::before
         font-family: "Font Awesome 5 Free"
         font-weight: 400
@@ -31,10 +24,15 @@ h1
 
     .star-rating__label:hover::before,
     .star-rating__label:hover ~ .star-rating__label:before
+        font-weight: 900
+        color: rgba(255, 255, 150, 100)
+
+    .star-rating__label--checked::before,
+    .star-rating__label--checked ~ .star-rating__label:before
         font-family: "Font Awesome 5 Free"
         font-weight: 900
         content: "\f005"
-        color: rgba(255, 255, 150, 100)
+        color: rgba(255, 255, 0, 100)
 
     .star-rating__input
         display: none

--- a/app/star-rating.sass
+++ b/app/star-rating.sass
@@ -17,6 +17,13 @@ h1
     direction: rtl
     border-width: 0px
 
+    .star-rating__clicked::before,
+    .star-rating__clicked ~ .star-rating__label:before
+        font-family: "Font Awesome 5 Free"
+        font-weight: 900
+        content: "\f005"
+        color: rgba(255, 255, 0, 100)
+
     .star-rating__label::before
         font-family: "Font Awesome 5 Free"
         font-weight: 400


### PR DESCRIPTION
Adjusts application so that original radio buttons are rendered as stars which change on hover and click.  Hovering over a star renders that star and all preceding stars as a light yellow. Clicking on a star applies a persistent darker yellow to the selected star and all those preceding it. Clicking a star also entails that checked="true" for that specific input button.  Click functionality allows for making new selections.

# **ORIGINAL DISPLAY WITHOUT SELECTION:**
![original-display](https://user-images.githubusercontent.com/15019389/36459139-5ecff498-1667-11e8-8d8a-d298a76341a8.png)


# **NEW DISPLAY WITHOUT SELECTION**
![display-after-bug-fix](https://user-images.githubusercontent.com/15019389/36459147-74b8cd52-1667-11e8-8074-a25b25fae001.png)


# **ORIGINAL DISPLAY WITH SELECTION**
![original-display-with-selection](https://user-images.githubusercontent.com/15019389/36461807-825a2672-16b7-11e8-8a23-e8ab7f01c39d.png)


# **NEW DISPLAY WITH SELECTION**
![display-with-selection-after-bug-fix](https://user-images.githubusercontent.com/15019389/36459177-949ae740-1667-11e8-8a18-2bcec24a7829.png)

# **ORIGINAL HOVER AND SELECT FUNCTIONALITY**
![old-stars](https://user-images.githubusercontent.com/15019389/36461841-b1e383b6-16b7-11e8-85f3-c02b708a1a5f.gif)


# **NEW HOVER AND SELECT FUNCTIONALITY**
![new-stars](https://user-images.githubusercontent.com/15019389/36460394-f594ecbc-166c-11e8-9386-f2eb83e6027e.gif)
